### PR TITLE
PCIe sub-system based design for APC/PPC2100

### DIFF
--- a/hardware/boards/br-antaresif/mn-single-pcie-drv/include/dualprocshm-mem.h
+++ b/hardware/boards/br-antaresif/mn-single-pcie-drv/include/dualprocshm-mem.h
@@ -10,7 +10,7 @@ to be used for the platform.
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-Copyright (c) 2014, Kalycito Infotech Private Limited
+Copyright (c) 2015, Kalycito Infotech Private Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -54,10 +54,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* BASE ADDRESSES */
 #define SHARED_MEM_BASE             SRAM_0_BASE
 #define SHARED_MEM_SPAN             SRAM_0_SIZE
-#define COMMON_MEM_BASE             ONCHIP_MEMORY2_0_BASE
+#define COMMON_MEM_BASE             PCIE_SUBSYSTEM_ONCHIP_MEMORY_BASE
 #define MEM_ADDR_TABLE_BASE         (COMMON_MEM_BASE + MAX_COMMON_MEM_SIZE)
 #define MEM_INTR_BASE               (MEM_ADDR_TABLE_BASE + MAX_DYNAMIC_BUFF_SIZE)
-#define TARGET_SYNC_INT_BASE        (PCIE_HARD_IP_0_BASE + 0x50)
+#define TARGET_SYNC_INT_BASE        (PCIE_SUBSYSTEM_PCIE_IP_BASE + 0x50)
 
 /* Queue Size */
 #define CONFIG_EVENT_SIZE_CIRCBUF_KERNEL_TO_USER    4096

--- a/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/components.ipx
+++ b/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/components.ipx
@@ -2,4 +2,5 @@
 <library>
     <path path="../../../../../oplk/hardware/ipcore/altera/components.ipx" />
     <path path="../../../../../oplk/hardware/ipcore/altera/qsys/mn_pcp.qsys"/>
+    <path path="../../../../../oplk/hardware/ipcore/altera/qsys/pcie_sub.qsys"/>
 </library>

--- a/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/mnSinglePcieDrv.qsys
+++ b/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/mnSinglePcieDrv.qsys
@@ -16,20 +16,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
-         type = "int";
-      }
-      datum sopceditor_expanded
-      {
-         value = "0";
-         type = "boolean";
-      }
-   }
-   element atomicmodify_1
-   {
-      datum _sortIndex
-      {
-         value = "11";
+         value = "12";
          type = "int";
       }
       datum sopceditor_expanded
@@ -98,14 +85,6 @@
          type = "String";
       }
    }
-   element pcie_hard_ip_0.cra
-   {
-      datum baseAddress
-      {
-         value = "32768";
-         type = "String";
-      }
-   }
    element epcs_flash_controller.epcs_control_port
    {
       datum baseAddress
@@ -132,19 +111,6 @@
          type = "boolean";
       }
    }
-   element host_benchmark
-   {
-      datum _sortIndex
-      {
-         value = "16";
-         type = "int";
-      }
-      datum sopceditor_expanded
-      {
-         value = "0";
-         type = "boolean";
-      }
-   }
    element openmac_0.macReg
    {
       datum baseAddress
@@ -161,45 +127,27 @@
          type = "String";
       }
    }
-   element mm_bridge_0
-   {
-      datum _sortIndex
-      {
-         value = "14";
-         type = "int";
-      }
-      datum sopceditor_expanded
-      {
-         value = "0";
-         type = "boolean";
-      }
-   }
-   element onchip_memory2_0
-   {
-      datum _sortIndex
-      {
-         value = "13";
-         type = "int";
-      }
-      datum sopceditor_expanded
-      {
-         value = "1";
-         type = "boolean";
-      }
-   }
    element openmac_0
    {
       datum _sortIndex
       {
-         value = "12";
+         value = "10";
          type = "int";
       }
    }
-   element pcie_hard_ip_0
+   element pcie_subsystem.pcie_config
+   {
+      datum baseAddress
+      {
+         value = "49152";
+         type = "String";
+      }
+   }
+   element pcie_subsystem
    {
       datum _sortIndex
       {
-         value = "15";
+         value = "11";
          type = "int";
       }
    }
@@ -209,6 +157,14 @@
       {
          value = "4";
          type = "int";
+      }
+   }
+   element pcie_subsystem.pcp_to_shmem_bridge
+   {
+      datum baseAddress
+      {
+         value = "32768";
+         type = "String";
       }
    }
    element remote_update
@@ -224,19 +180,6 @@
          type = "boolean";
       }
    }
-   element atomicmodify_1.s0
-   {
-      datum _lockedAddress
-      {
-         value = "1";
-         type = "boolean";
-      }
-      datum baseAddress
-      {
-         value = "524288";
-         type = "String";
-      }
-   }
    element atomicmodify_0.s0
    {
       datum _lockedAddress
@@ -250,35 +193,11 @@
          type = "String";
       }
    }
-   element host_benchmark.s1
-   {
-      datum baseAddress
-      {
-         value = "4096";
-         type = "String";
-      }
-   }
    element testport_pio.s1
    {
       datum baseAddress
       {
-         value = "57344";
-         type = "String";
-      }
-   }
-   element onchip_memory2_0.s1
-   {
-      datum baseAddress
-      {
-         value = "49152";
-         type = "String";
-      }
-   }
-   element onchip_memory2_0.s2
-   {
-      datum baseAddress
-      {
-         value = "0";
+         value = "8192";
          type = "String";
       }
    }
@@ -286,7 +205,7 @@
    {
       datum _sortIndex
       {
-         value = "9";
+         value = "8";
          type = "int";
       }
       datum sopceditor_expanded
@@ -312,7 +231,7 @@
    {
       datum _sortIndex
       {
-         value = "17";
+         value = "13";
          type = "int";
       }
       datum sopceditor_expanded
@@ -325,7 +244,7 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "9";
          type = "int";
       }
       datum sopceditor_expanded
@@ -362,7 +281,7 @@
  <parameter name="projectName">mn-single-pcie-drv.qpf</parameter>
  <parameter name="sopcBorderPoints" value="false" />
  <parameter name="systemHash" value="1" />
- <parameter name="timeStamp" value="1446555743398" />
+ <parameter name="timeStamp" value="1450687098045" />
  <parameter name="useTestBenchNamingPattern" value="false" />
  <instanceScript></instanceScript>
  <interface name="clk50" internal="clk50.clk_in" type="clock" dir="end" />
@@ -399,87 +318,71 @@
    internal="openmac_0.rmii"
    type="conduit"
    dir="end" />
- <interface name="openmac_0_mactimerout" internal="openmac_0.macTimerOut" />
  <interface
-   name="pcie_rx_in"
-   internal="pcie_hard_ip_0.rx_in"
+   name="pcie_ip_rx_in"
+   internal="pcie_subsystem.pcie_ip_rx_in"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_tx_out"
-   internal="pcie_hard_ip_0.tx_out"
+   name="pcie_ip_tx_out"
+   internal="pcie_subsystem.pcie_ip_tx_out"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_reconfig_togxb"
-   internal="pcie_hard_ip_0.reconfig_togxb"
+   name="pcie_ip_reconfig_togxb"
+   internal="pcie_subsystem.pcie_ip_reconfig_togxb"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_reconfig_gxbclk"
-   internal="pcie_hard_ip_0.reconfig_gxbclk"
-   type="clock"
-   dir="end" />
- <interface
-   name="pcie_reconfig_fromgxb_0"
-   internal="pcie_hard_ip_0.reconfig_fromgxb_0"
+   name="pcie_ip_reconfig_fromgxb_0"
+   internal="pcie_subsystem.pcie_ip_reconfig_fromgxb_0"
    type="conduit"
    dir="end" />
  <interface name="clk125" internal="clk125.clk_in" type="clock" dir="end" />
  <interface
-   name="pcie_refclk"
-   internal="pcie_hard_ip_0.refclk"
+   name="pcie_ip_refclk"
+   internal="pcie_subsystem.pcie_ip_refclk"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_test_in"
-   internal="pcie_hard_ip_0.test_in"
+   name="pcie_ip_test_in"
+   internal="pcie_subsystem.pcie_ip_test_in"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_rstn"
-   internal="pcie_hard_ip_0.pcie_rstn"
+   name="pcie_ip_pcie_rstn"
+   internal="pcie_subsystem.pcie_ip_pcie_rstn"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_clocks_sim"
-   internal="pcie_hard_ip_0.clocks_sim"
+   name="pcie_ip_clocks_sim"
+   internal="pcie_subsystem.pcie_ip_clocks_sim"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_reconfig_busy"
-   internal="pcie_hard_ip_0.reconfig_busy"
+   name="pcie_ip_reconfig_busy"
+   internal="pcie_subsystem.pcie_ip_reconfig_busy"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_pipe_ext"
-   internal="pcie_hard_ip_0.pipe_ext"
+   name="pcie_ip_pipe_ext"
+   internal="pcie_subsystem.pcie_ip_pipe_ext"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_powerdown"
-   internal="pcie_hard_ip_0.powerdown"
+   name="pcie_ip_powerdown"
+   internal="pcie_subsystem.pcie_ip_powerdown"
    type="conduit"
    dir="end" />
  <interface
-   name="pcie_test_out"
-   internal="pcie_hard_ip_0.test_out"
-   type="conduit"
-   dir="end" />
- <interface
-   name="host_benchmark_pio"
-   internal="host_benchmark.external_connection"
+   name="pcie_0_benchmark_pio"
+   internal="pcie_subsystem.pcie_benchmark_external_connection"
    type="conduit"
    dir="end" />
  <interface
    name="pcp_0_cpu_resetrequest"
    internal="pcp_0.cpu_resetrequest"
    type="conduit"
-   dir="end" />
- <interface
-   name="pcie_cal_blk_clk"
-   internal="pcie_hard_ip_0.cal_blk_clk"
-   type="clock"
    dir="end" />
  <interface
    name="openmac_0_pktactivity"
@@ -496,6 +399,12 @@
    internal="pcp_0.powerlink_led"
    type="conduit"
    dir="end" />
+ <interface
+   name="led_external_connection"
+   internal="pcie_subsystem.led_external_connection" />
+ <interface
+   name="button_external_connection"
+   internal="pcie_subsystem.button_external_connection" />
  <module kind="clock_source" version="13.0" enabled="1" name="clk50">
   <parameter name="clockFrequency" value="50000000" />
   <parameter name="clockFrequencyKnown" value="true" />
@@ -644,194 +553,35 @@
   <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone IV GX" />
  </module>
  <module
-   kind="altera_pcie_hard_ip"
-   version="13.0"
+   kind="pcie_sub"
+   version="1.0"
    enabled="1"
-   name="pcie_hard_ip_0">
-  <parameter name="under_test" value="0" />
-  <parameter name="INTENDED_DEVICE_FAMILY" value="Cyclone IV GX" />
-  <parameter name="pcie_qsys" value="1" />
-  <parameter name="my_gen2_lane_rate_mode" value="false" />
-  <parameter name="max_link_width" value="1" />
-  <parameter name="p_pcie_txrx_clock" value="100 MHz" />
-  <parameter name="p_pcie_app_clk" value="0" />
-  <parameter name="p_pcie_test_out_width" value="9bits" />
-  <parameter name="no_soft_reset" value="false" />
-  <parameter name="p_pcie_version" value="2.0" />
-  <parameter name="NUM_PREFETCH_MASTERS" value="1" />
-  <parameter name="bar0_io_space" value="false" />
-  <parameter name="bar1_io_space" value="false" />
-  <parameter name="bar2_io_space" value="false" />
-  <parameter name="bar3_io_space" value="false" />
-  <parameter name="bar4_io_space" value="false" />
-  <parameter name="bar5_io_space" value="false" />
-  <parameter name="fixed_address_mode" value="0" />
-  <parameter name="CB_P2A_FIXED_AVALON_ADDR_B0" value="0" />
-  <parameter name="CB_P2A_FIXED_AVALON_ADDR_B1" value="0" />
-  <parameter name="CB_P2A_FIXED_AVALON_ADDR_B2" value="0" />
-  <parameter name="CB_P2A_FIXED_AVALON_ADDR_B3" value="0" />
-  <parameter name="CB_P2A_FIXED_AVALON_ADDR_B4" value="0" />
-  <parameter name="CB_P2A_FIXED_AVALON_ADDR_B5" value="0" />
-  <parameter name="BAR Type">32 bit Non-Prefetchable,32 bit Non-Prefetchable,Not used,Not used,Not used,Not used</parameter>
+   name="pcie_subsystem">
   <parameter name="vendor_id" value="5751" />
   <parameter name="device_id" value="59401" />
   <parameter name="revision_id" value="1" />
   <parameter name="class_code" value="557104" />
   <parameter name="subsystem_vendor_id" value="5751" />
-  <parameter name="subsystem_device_id" value="58658" />
-  <parameter name="port_link_number" value="1" />
-  <parameter name="msi_function_count" value="0" />
-  <parameter name="enable_msi_64bit_addressing" value="true" />
-  <parameter name="enable_function_msix_support" value="false" />
-  <parameter name="eie_before_nfts_count" value="4" />
-  <parameter name="enable_completion_timeout_disable" value="false" />
-  <parameter name="completion_timeout" value="NONE" />
-  <parameter name="enable_adapter_half_rate_mode" value="false" />
-  <parameter name="msix_pba_bir" value="0" />
-  <parameter name="msix_pba_offset" value="0" />
-  <parameter name="msix_table_bir" value="0" />
-  <parameter name="msix_table_offset" value="0" />
-  <parameter name="msix_table_size" value="0" />
-  <parameter name="use_crc_forwarding" value="false" />
-  <parameter name="surprise_down_error_support" value="false" />
-  <parameter name="dll_active_report_support" value="false" />
-  <parameter name="bar_io_window_size" value="32BIT" />
-  <parameter name="bar_prefetchable" value="32" />
-  <parameter name="hot_plug_support" value="0" />
-  <parameter name="no_command_completed" value="true" />
-  <parameter name="slot_power_limit" value="0" />
-  <parameter name="slot_power_scale" value="0" />
-  <parameter name="slot_number" value="0" />
-  <parameter name="enable_slot_register" value="false" />
-  <parameter name="link_common_clock" value="1" />
-  <parameter name="advanced_errors" value="false" />
-  <parameter name="enable_ecrc_check" value="false" />
-  <parameter name="enable_ecrc_gen" value="false" />
-  <parameter name="my_advanced_errors" value="true" />
-  <parameter name="my_enable_ecrc_check" value="true" />
-  <parameter name="my_enable_ecrc_gen" value="true" />
-  <parameter name="max_payload_size" value="0" />
-  <parameter name="p_pcie_target_performance_preset" value="Maximum" />
-  <parameter name="credit_buffer_allocation_aux" value="ABSOLUTE" />
-  <parameter name="RX_BUF" value="9" />
-  <parameter name="RH_NUM" value="7" />
-  <parameter name="G_TAG_NUM0" value="32" />
-  <parameter name="endpoint_l0_latency" value="0" />
-  <parameter name="endpoint_l1_latency" value="0" />
-  <parameter name="enable_l1_aspm" value="false" />
-  <parameter name="l01_entry_latency" value="31" />
-  <parameter name="diffclock_nfts_count" value="255" />
-  <parameter name="sameclock_nfts_count" value="255" />
-  <parameter name="l1_exit_latency_sameclock" value="7" />
-  <parameter name="l1_exit_latency_diffclock" value="7" />
-  <parameter name="l0_exit_latency_sameclock" value="7" />
-  <parameter name="l0_exit_latency_diffclock" value="7" />
-  <parameter name="gen2_diffclock_nfts_count" value="255" />
-  <parameter name="gen2_sameclock_nfts_count" value="255" />
-  <parameter name="CG_COMMON_CLOCK_MODE" value="1" />
-  <parameter name="CB_PCIE_MODE" value="0" />
-  <parameter name="AST_LITE" value="0" />
-  <parameter name="CB_PCIE_RX_LITE" value="0" />
-  <parameter name="CG_RXM_IRQ_NUM" value="16" />
-  <parameter name="CG_AVALON_S_ADDR_WIDTH" value="20" />
-  <parameter name="bypass_tl" value="false" />
-  <parameter name="CG_IMPL_CRA_AV_SLAVE_PORT" value="1" />
-  <parameter name="CG_NO_CPL_REORDERING" value="1" />
-  <parameter name="CG_ENABLE_A2P_INTERRUPT" value="1" />
-  <parameter name="CG_IRQ_BIT_ENA" value="65535" />
-  <parameter name="CB_A2P_ADDR_MAP_IS_FIXED" value="1" />
-  <parameter name="CB_A2P_ADDR_MAP_NUM_ENTRIES" value="1" />
-  <parameter name="CB_A2P_ADDR_MAP_PASS_THRU_BITS" value="32" />
-  <parameter name="PCIe Address 63:32">0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000</parameter>
-  <parameter name="PCIe Address 31:0">0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000</parameter>
-  <parameter name="RXM_DATA_WIDTH" value="64" />
-  <parameter name="RXM_BEN_WIDTH" value="8" />
-  <parameter name="CB_TXS_ADDRESS_WIDTH" value="7" />
-  <parameter name="TL_SELECTION" value="1" />
-  <parameter name="pcie_mode" value="SHARED_MODE" />
-  <parameter name="enable_coreclk_out_half_rate" value="false" />
-  <parameter name="low_priority_vc" value="0" />
-  <parameter name="SLAVE_ADDRESS_MAP_0" value="20" />
-  <parameter name="SLAVE_ADDRESS_MAP_1" value="13" />
-  <parameter name="SLAVE_ADDRESS_MAP_2" value="0" />
-  <parameter name="SLAVE_ADDRESS_MAP_3" value="0" />
-  <parameter name="SLAVE_ADDRESS_MAP_4" value="0" />
-  <parameter name="SLAVE_ADDRESS_MAP_5" value="0" />
-  <parameter name="SLAVE_ADDRESS_MAP_1_0" value="0" />
-  <parameter name="SLAVE_ADDRESS_MAP_3_2" value="0" />
-  <parameter name="SLAVE_ADDRESS_MAP_5_4" value="0" />
-  <parameter name="deviceFamily" value="Cyclone IV GX" />
-  <parameter name="AUTO_CAL_BLK_CLK_CLOCK_RATE" value="0" />
-  <parameter name="AUTO_CAL_BLK_CLK_CLOCK_DOMAIN" value="5" />
-  <parameter name="AUTO_CAL_BLK_CLK_RESET_DOMAIN" value="5" />
+  <parameter name="subsystem_id" value="58658" />
+  <parameter name="AUTO_GENERATION_ID" value="0" />
+  <parameter name="AUTO_UNIQUE_ID">$${FILENAME}_pcie_subsystem</parameter>
+  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone IV GX" />
   <parameter name="AUTO_DEVICE" value="EP4CGX30CF19I7" />
+  <parameter name="AUTO_CLK_CLOCK_RATE" value="50000000" />
+  <parameter name="AUTO_CLK_CLOCK_DOMAIN" value="4" />
+  <parameter name="AUTO_CLK_RESET_DOMAIN" value="4" />
+  <parameter name="AUTO_CLK100_CLOCK_RATE" value="100000000" />
+  <parameter name="AUTO_CLK100_CLOCK_DOMAIN" value="1" />
+  <parameter name="AUTO_CLK100_RESET_DOMAIN" value="1" />
+  <parameter name="AUTO_PCIE_IP_FIXEDCLK_CLOCK_RATE" value="125000000" />
+  <parameter name="AUTO_PCIE_IP_FIXEDCLK_CLOCK_DOMAIN" value="2" />
+  <parameter name="AUTO_PCIE_IP_FIXEDCLK_RESET_DOMAIN" value="2" />
  </module>
  <module kind="clock_source" version="13.0" enabled="1" name="clk125">
-  <parameter name="clockFrequency" value="100000000" />
+  <parameter name="clockFrequency" value="125000000" />
   <parameter name="clockFrequencyKnown" value="true" />
   <parameter name="inputClockFrequency" value="0" />
   <parameter name="resetSynchronousEdges" value="NONE" />
- </module>
- <module
-   kind="altera_avalon_onchip_memory2"
-   version="13.0.1.99.2"
-   enabled="1"
-   name="onchip_memory2_0">
-  <parameter name="allowInSystemMemoryContentEditor" value="false" />
-  <parameter name="blockType" value="AUTO" />
-  <parameter name="dataWidth" value="32" />
-  <parameter name="dualPort" value="true" />
-  <parameter name="initMemContent" value="true" />
-  <parameter name="initializationFileName" value="onchip_mem.hex" />
-  <parameter name="instanceID" value="NONE" />
-  <parameter name="memorySize" value="4096" />
-  <parameter name="readDuringWriteMode" value="DONT_CARE" />
-  <parameter name="simAllowMRAMContentsFile" value="false" />
-  <parameter name="simMemInitOnlyFilename" value="0" />
-  <parameter name="singleClockOperation" value="false" />
-  <parameter name="slave1Latency" value="1" />
-  <parameter name="slave2Latency" value="1" />
-  <parameter name="useNonDefaultInitFile" value="false" />
-  <parameter name="useShallowMemBlocks" value="false" />
-  <parameter name="writable" value="true" />
-  <parameter name="autoInitializationFileName">$${FILENAME}_onchip_memory2_0</parameter>
-  <parameter name="deviceFamily" value="Cyclone IV GX" />
-  <parameter name="deviceFeatures">ADDRESS_STALL 1 CELL_LEVEL_BACK_ANNOTATION_DISABLED 0 COMPILER_SUPPORT 1 DSP 0 DSP_SHIFTER_BLOCK 0 DUMP_ASM_LAB_BITS_FOR_POWER 1 EMUL 1 ENABLE_ADVANCED_IO_ANALYSIS_GUI_FEATURES 1 EPCS 1 ESB 0 FAKE1 0 FAKE2 0 FAKE3 0 FAMILY_LEVEL_INSTALLATION_ONLY 1 FITTER_USE_FALLING_EDGE_DELAY 0 GENERATE_DC_ON_CURRENT_WARNING_FOR_INTERNAL_CLAMPING_DIODE 0 HARDCOPY 0 HAS_18_BIT_MULTS 0 HAS_ACE_SUPPORT 1 HAS_ADJUSTABLE_OUTPUT_IO_TIMING_MEAS_POINT 1 HAS_ADVANCED_IO_INVERTED_CORNER 0 HAS_ADVANCED_IO_POWER_SUPPORT 1 HAS_ADVANCED_IO_TIMING_SUPPORT 1 HAS_ALM_SUPPORT 0 HAS_ATOM_AND_ROUTING_POWER_MODELED_TOGETHER 0 HAS_AUTO_DERIVE_CLOCK_UNCERTAINTY_SUPPORT 1 HAS_AUTO_FIT_SUPPORT 1 HAS_BALANCED_OPT_TECHNIQUE_SUPPORT 1 HAS_BENEFICIAL_SKEW_SUPPORT 1 HAS_BITLEVEL_DRIVE_STRENGTH_CONTROL 1 HAS_BSDL_FILE_GENERATION 1 HAS_CGA_SUPPORT 1 HAS_CHECK_NETLIST_SUPPORT 0 HAS_CLOCK_REGION_CHECKER_ENABLED 1 HAS_CORE_JUNCTION_TEMP_DERATING 0 HAS_CROSSTALK_SUPPORT 0 HAS_CUSTOM_REGION_SUPPORT 1 HAS_DAP_JTAG_FROM_HPS 0 HAS_DATA_DRIVEN_ACVQ_HSSI_SUPPORT 0 HAS_DDB_FDI_SUPPORT 0 HAS_DESIGN_ANALYZER_SUPPORT 1 HAS_DETAILED_IO_RAIL_POWER_MODEL 1 HAS_DETAILED_LEIM_STATIC_POWER_MODEL 1 HAS_DETAILED_LE_POWER_MODEL 1 HAS_DETAILED_ROUTING_MUX_STATIC_POWER_MODEL 1 HAS_DETAILED_THERMAL_CIRCUIT_PARAMETER_SUPPORT 1 HAS_DEVICE_MIGRATION_SUPPORT 1 HAS_DIAGONAL_MIGRATION_SUPPORT 0 HAS_EMIF_TOOLKIT_SUPPORT 0 HAS_ERROR_DETECTION_SUPPORT 0 HAS_FAMILY_VARIANT_MIGRATION_SUPPORT 0 HAS_FANOUT_FREE_NODE_SUPPORT 1 HAS_FAST_FIT_SUPPORT 1 HAS_FITTER_EARLY_TIMING_ESTIMATE_SUPPORT 1 HAS_FITTER_ECO_SUPPORT 1 HAS_FIT_NETLIST_OPT_RETIME_SUPPORT 1 HAS_FIT_NETLIST_OPT_SUPPORT 1 HAS_FORMAL_VERIFICATION_SUPPORT 0 HAS_FPGA_XCHANGE_SUPPORT 1 HAS_FSAC_LUTRAM_REGISTER_PACKING_SUPPORT 0 HAS_FULL_DAT_MIN_TIMING_SUPPORT 1 HAS_FULL_INCREMENTAL_DESIGN_SUPPORT 1 HAS_FUNCTIONAL_SIMULATION_SUPPORT 1 HAS_FUNCTIONAL_VERILOG_SIMULATION_SUPPORT 0 HAS_FUNCTIONAL_VHDL_SIMULATION_SUPPORT 0 HAS_GLITCH_FILTERING_SUPPORT 1 HAS_HC_READY_SUPPORT 0 HAS_HIGH_SPEED_LOW_POWER_TILE_SUPPORT 0 HAS_HOLD_TIME_AVOIDANCE_ACROSS_CLOCK_SPINE_SUPPORT 1 HAS_HSPICE_WRITER_SUPPORT 1 HAS_HSSI_POWER_CALCULATOR 1 HAS_IBISO_WRITER_SUPPORT 0 HAS_INCREMENTAL_DAT_SUPPORT 1 HAS_INCREMENTAL_SYNTHESIS_SUPPORT 1 HAS_INTERFACE_PLANNER_SUPPORT 0 HAS_IO_ASSIGNMENT_ANALYSIS_SUPPORT 1 HAS_IO_DECODER 0 HAS_IO_PLACEMENT_OPTIMIZATION_SUPPORT 1 HAS_IO_SMART_RECOMPILE_SUPPORT 0 HAS_JITTER_SUPPORT 1 HAS_JTAG_SLD_HUB_SUPPORT 1 HAS_LIMITED_TCL_FITTER_SUPPORT 0 HAS_LOGIC_LOCK_SUPPORT 1 HAS_MICROPROCESSOR 0 HAS_MIF_SMART_COMPILE_SUPPORT 1 HAS_MINMAX_TIMING_MODELING_SUPPORT 1 HAS_MIN_TIMING_ANALYSIS_SUPPORT 1 HAS_MUX_RESTRUCTURE_SUPPORT 1 HAS_NEW_HC_FLOW_SUPPORT 0 HAS_NEW_SERDES_MAX_RESOURCE_COUNT_REPORTING_SUPPORT 1 HAS_NEW_VPR_SUPPORT 1 HAS_NONSOCKET_TECHNOLOGY_MIGRATION_SUPPORT 0 HAS_NO_HARDBLOCK_PARTITION_SUPPORT 0 HAS_NO_JTAG_USERCODE_SUPPORT 0 HAS_OPERATING_SETTINGS_AND_CONDITIONS_REPORTING_SUPPORT 1 HAS_PAD_LOCATION_ASSIGNMENT_SUPPORT 0 HAS_PARTIAL_RECONFIG_SUPPORT 0 HAS_PHYSICAL_NETLIST_OUTPUT 0 HAS_PHYSICAL_ROUTING_SUPPORT 0 HAS_PIN_SPECIFIC_VOLTAGE_SUPPORT 1 HAS_PLDM_REF_SUPPORT 1 HAS_POWER_ESTIMATION_SUPPORT 1 HAS_PRELIMINARY_CLOCK_UNCERTAINTY_NUMBERS 0 HAS_PRE_FITTER_FPP_SUPPORT 0 HAS_PRE_FITTER_LUTRAM_NETLIST_CHECKER_ENABLED 0 HAS_PVA_SUPPORT 1 HAS_RCF_SUPPORT 1 HAS_RCF_SUPPORT_FOR_DEBUGGING 0 HAS_RED_BLACK_SEPARATION_SUPPORT 0 HAS_RE_LEVEL_TIMING_GRAPH_SUPPORT 1 HAS_RISEFALL_DELAY_SUPPORT 1 HAS_SIGNAL_PROBE_SUPPORT 1 HAS_SIGNAL_TAP_SUPPORT 1 HAS_SIMULATOR_SUPPORT 0 HAS_SPLIT_IO_SUPPORT 1 HAS_SPLIT_LC_SUPPORT 1 HAS_SYNTH_FSYN_NETLIST_OPT_SUPPORT 1 HAS_SYNTH_NETLIST_OPT_RETIME_SUPPORT 1 HAS_SYNTH_NETLIST_OPT_SUPPORT 1 HAS_TCL_FITTER_SUPPORT 0 HAS_TECHNOLOGY_MIGRATION_SUPPORT 0 HAS_TEMPLATED_REGISTER_PACKING_SUPPORT 1 HAS_TIME_BORROWING_SUPPORT 0 HAS_TIMING_DRIVEN_SYNTHESIS_SUPPORT 1 HAS_TIMING_INFO_SUPPORT 1 HAS_TIMING_OPERATING_CONDITIONS 1 HAS_TIMING_SIMULATION_SUPPORT 1 HAS_TITAN_BASED_MAC_REGISTER_PACKER_SUPPORT 0 HAS_U2B2_SUPPORT 0 HAS_USER_HIGH_SPEED_LOW_POWER_TILE_SUPPORT 0 HAS_USE_FITTER_INFO_SUPPORT 1 HAS_VCCPD_POWER_RAIL 0 HAS_VERTICAL_MIGRATION_SUPPORT 1 HAS_VIEWDRAW_SYMBOL_SUPPORT 0 HAS_VIO_SUPPORT 1 HAS_VIRTUAL_DEVICES 0 HAS_WYSIWYG_DFFEAS_SUPPORT 1 HAS_XIBISO_WRITER_SUPPORT 1 IFP_USE_LEGACY_IO_CHECKER 0 INCREMENTAL_DESIGN_SUPPORTS_COMPATIBLE_CONSTRAINTS 1 INSTALLED 0 IS_CONFIG_ROM 0 IS_DEFAULT_FAMILY 1 IS_HARDCOPY_FAMILY 0 LVDS_IO 1 M10K_MEMORY 0 M144K_MEMORY 0 M20K_MEMORY 0 M4K_MEMORY 0 M512_MEMORY 0 M9K_MEMORY 1 MLAB_MEMORY 0 MRAM_MEMORY 0 NOT_LISTED 0 NO_RPE_SUPPORT 0 NO_SUPPORT_FOR_LOGICLOCK_CONTENT_BACK_ANNOTATION 1 NO_SUPPORT_FOR_STA_CLOCK_UNCERTAINTY_CHECK 0 NO_TDC_SUPPORT 0 POSTFIT_BAK_DATABASE_EXPORT_ENABLED 1 POSTMAP_BAK_DATABASE_EXPORT_ENABLED 1 PROGRAMMER_SUPPORT 1 QFIT_IN_DEVELOPMENT 0 QMAP_IN_DEVELOPMENT 0 RAM_LOGICAL_NAME_CHECKING_IN_CUT_ENABLED 1 REPORTS_METASTABILITY_MTBF 1 REQUIRES_INSTALLATION_PATCH 0 REQUIRES_LIST_OF_TEMPERATURE_AND_VOLTAGE_OPERATING_CONDITIONS 1 RESERVES_SIGNAL_PROBE_PINS 0 RESOLVE_MAX_FANOUT_EARLY 1 RESOLVE_MAX_FANOUT_LATE 0 RESPECTS_FIXED_SIZED_LOCKED_LOCATION_LOGICLOCK 1 RESTRICTED_USER_SELECTION 0 RISEFALL_SUPPORT_IS_HIDDEN 0 STRICT_TIMING_DB_CHECKS 0 SUPPORTS_ADDITIONAL_OPTIONS_FOR_UNUSED_IO 0 SUPPORTS_CRC 1 SUPPORTS_DIFFERENTIAL_AIOT_BOARD_TRACE_MODEL 1 SUPPORTS_DSP_BALANCING_BACK_ANNOTATION 0 SUPPORTS_GENERATION_OF_EARLY_POWER_ESTIMATOR_FILE 1 SUPPORTS_GLOBAL_SIGNAL_BACK_ANNOTATION 0 SUPPORTS_MAC_CHAIN_OUT_ADDER 0 SUPPORTS_RAM_PACKING_BACK_ANNOTATION 0 SUPPORTS_REG_PACKING_BACK_ANNOTATION 0 SUPPORTS_SIGNALPROBE_REGISTER_PIPELINING 1 SUPPORTS_SINGLE_ENDED_AIOT_BOARD_TRACE_MODEL 1 SUPPORTS_USER_MANUAL_LOGIC_DUPLICATION 1 TMV_RUN_CUSTOMIZABLE_VIEWER 1 TMV_RUN_INTERNAL_DETAILS 1 TMV_RUN_INTERNAL_DETAILS_ON_IO 0 TMV_RUN_INTERNAL_DETAILS_ON_IOBUF 1 TMV_RUN_INTERNAL_DETAILS_ON_LCELL 0 TMV_RUN_INTERNAL_DETAILS_ON_LRAM 0 TRANSCEIVER_3G_BLOCK 1 TRANSCEIVER_6G_BLOCK 1 USES_ACV_FOR_FLED 1 USES_ADB_FOR_BACK_ANNOTATION 1 USES_ALTERA_LNSIM 0 USES_ASIC_ROUTING_POWER_CALCULATOR 0 USES_DATA_DRIVEN_PLL_COMPUTATION_UTIL 1 USES_DEV 1 USES_ICP_FOR_ECO_FITTER 0 USES_LIBERTY_TIMING 0 USES_POWER_SIGNAL_ACTIVITIES 1 USES_THIRD_GENERATION_TIMING_MODELS_TIS 1 USES_U2B2_TIMING_MODELS 0 USE_ADVANCED_IO_POWER_BY_DEFAULT 1 USE_ADVANCED_IO_TIMING_BY_DEFAULT 1 USE_BASE_FAMILY_DDB_PATH 0 USE_OCT_AUTO_CALIBRATION 1 USE_RELAX_IO_ASSIGNMENT_RULES 0 USE_RISEFALL_ONLY 1 USE_SEPARATE_LIST_FOR_TECH_MIGRATION 0 USE_SINGLE_COMPILER_PASS_PLL_MIF_FILE_WRITER 1 USE_TITAN_IO_BASED_IO_REGISTER_PACKER_UTIL 0 WYSIWYG_BUS_WIDTH_CHECKING_IN_CUT_ENABLED 1</parameter>
- </module>
- <module
-   kind="altera_avalon_mm_bridge"
-   version="13.0"
-   enabled="1"
-   name="mm_bridge_0">
-  <parameter name="DATA_WIDTH" value="32" />
-  <parameter name="SYMBOL_WIDTH" value="8" />
-  <parameter name="ADDRESS_WIDTH" value="20" />
-  <parameter name="ADDRESS_UNITS" value="SYMBOLS" />
-  <parameter name="MAX_BURST_SIZE" value="1" />
-  <parameter name="MAX_PENDING_RESPONSES" value="1" />
-  <parameter name="LINEWRAPBURSTS" value="0" />
-  <parameter name="PIPELINE_COMMAND" value="1" />
-  <parameter name="PIPELINE_RESPONSE" value="1" />
-  <parameter name="AUTO_CLK_CLOCK_RATE" value="100000000" />
-  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone IV GX" />
- </module>
- <module
-   kind="altera_avalon_pio"
-   version="13.0.1.99.2"
-   enabled="1"
-   name="host_benchmark">
-  <parameter name="bitClearingEdgeCapReg" value="false" />
-  <parameter name="bitModifyingOutReg" value="true" />
-  <parameter name="captureEdge" value="false" />
-  <parameter name="direction" value="Output" />
-  <parameter name="edgeType" value="RISING" />
-  <parameter name="generateIRQ" value="false" />
-  <parameter name="irqType" value="LEVEL" />
-  <parameter name="resetValue" value="0" />
-  <parameter name="simDoTestBenchWiring" value="false" />
-  <parameter name="simDrivenValue" value="0" />
-  <parameter name="width" value="8" />
-  <parameter name="clockRate" value="50000000" />
  </module>
  <module
    kind="altera_avalon_pio"
@@ -852,10 +602,6 @@
   <parameter name="clockRate" value="50000000" />
  </module>
  <module kind="atomicmodify" version="1.1.0" enabled="1" name="atomicmodify_0">
-  <parameter name="sys_m0Addrw" value="19" />
-  <parameter name="AUTO_C0_CLOCK_RATE" value="100000000" />
- </module>
- <module kind="atomicmodify" version="1.1.0" enabled="1" name="atomicmodify_1">
   <parameter name="sys_m0Addrw" value="19" />
   <parameter name="AUTO_C0_CLOCK_RATE" value="100000000" />
  </module>
@@ -1021,66 +767,26 @@
    kind="clock"
    version="13.0"
    start="clk125.clk"
-   end="pcie_hard_ip_0.fixedclk" />
+   end="pcie_subsystem.pcie_ip_fixedclk" />
  <connection
    kind="reset"
    version="13.0"
-   start="clk25.clk_reset"
+   start="clk100.clk_reset"
    end="clk125.clk_in_reset" />
  <connection
    kind="avalon"
    version="13.0"
-   start="pcie_hard_ip_0.bar1"
-   end="onchip_memory2_0.s2">
+   start="pcie_subsystem.bar0"
+   end="sram_0.uas">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x0000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
- <connection
-   kind="clock"
-   version="13.0"
-   start="clk100.clk"
-   end="onchip_memory2_0.clk1" />
- <connection
-   kind="clock"
-   version="13.0"
-   start="pcie_hard_ip_0.pcie_core_clk"
-   end="onchip_memory2_0.clk2" />
- <connection
-   kind="reset"
-   version="13.0"
-   start="clk25.clk_reset"
-   end="onchip_memory2_0.reset1" />
- <connection kind="clock" version="13.0" start="clk100.clk" end="mm_bridge_0.clk" />
- <connection kind="avalon" version="13.0" start="mm_bridge_0.m0" end="sram_0.uas">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="13.0"
-   start="pcie_hard_ip_0.bar0"
-   end="mm_bridge_0.s0">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="reset"
-   version="13.0"
-   start="pcie_hard_ip_0.pcie_core_reset"
-   end="mm_bridge_0.reset" />
- <connection
-   kind="reset"
-   version="13.0"
-   start="pcie_hard_ip_0.pcie_core_reset"
-   end="onchip_memory2_0.reset2" />
  <connection
    kind="avalon"
    version="13.0"
    start="pcp_0.slow_bridge"
-   end="pcie_hard_ip_0.cra">
+   end="pcie_subsystem.pcp_to_shmem_bridge">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x8000" />
   <parameter name="defaultConnection" value="false" />
@@ -1089,7 +795,7 @@
    kind="avalon"
    version="13.0"
    start="pcp_0.slow_bridge"
-   end="onchip_memory2_0.s1">
+   end="pcie_subsystem.pcie_config">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0xc000" />
   <parameter name="defaultConnection" value="false" />
@@ -1097,22 +803,18 @@
  <connection
    kind="reset"
    version="13.0"
-   start="pcie_hard_ip_0.pcie_core_reset"
-   end="host_benchmark.reset" />
+   start="clk50.clk_reset"
+   end="pcie_subsystem.reset" />
  <connection
-   kind="avalon"
+   kind="reset"
    version="13.0"
-   start="pcie_hard_ip_0.bar1"
-   end="host_benchmark.s1">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x1000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
+   start="clk100.clk_reset"
+   end="pcie_subsystem.reset" />
  <connection
    kind="clock"
    version="13.0"
    start="clk50.clk"
-   end="host_benchmark.clk" />
+   end="pcie_subsystem.clk" />
  <connection
    kind="reset"
    version="13.0"
@@ -1130,7 +832,7 @@
    start="pcp_0.slow_bridge"
    end="testport_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0xe000" />
+  <parameter name="baseAddress" value="0x2000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1165,34 +867,11 @@
    kind="clock"
    version="13.0"
    start="clk100.clk"
-   end="atomicmodify_1.c0" />
- <connection
-   kind="reset"
-   version="13.0"
-   start="pcie_hard_ip_0.pcie_core_reset"
-   end="atomicmodify_1.r0" />
- <connection
-   kind="avalon"
-   version="13.0"
-   start="mm_bridge_0.m0"
-   end="atomicmodify_1.s0">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00080000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="13.0"
-   start="atomicmodify_1.m0"
-   end="sram_0.uas">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
+   end="pcie_subsystem.clk100" />
  <connection
    kind="interrupt"
    version="13.0"
-   start="pcie_hard_ip_0.rxm_irq"
+   start="pcie_subsystem.sync_irq"
    end="openmac_0.timerPulse">
   <parameter name="irqNumber" value="0" />
  </connection>

--- a/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/mnSinglePcieDrv.sdc
+++ b/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/mnSinglePcieDrv.sdc
@@ -43,11 +43,6 @@ set_false_path -from [get_registers *]      -to [get_ports oFlash_DI]
 set_false_path -from [get_ports iFlash_DO]  -to [get_registers *]
 
 # ------------------------------------------------------------------------------
-# PCIe
-# -> Cut from/to pcie core clock
-set_clock_groups -asynchronous -group [get_clocks $clkpciecore]
-
-# ------------------------------------------------------------------------------
 # PHY LINK and LEDs
 # -> Cut path
 set_false_path -from [get_ports iLinkPlkPhy]    -to *

--- a/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/mnSinglePcieDrv.sdc
+++ b/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/mnSinglePcieDrv.sdc
@@ -16,7 +16,7 @@ set clk50       pllInst|altpll_component|auto_generated|pll1|clk[0]
 set clk100      pllInst|altpll_component|auto_generated|pll1|clk[1]
 set clk25       pllInst|altpll_component|auto_generated|pll1|clk[2]
 set clk125      pllInst|altpll_component|auto_generated|pll1|clk[3]
-set clkpciecore inst|pcie_hard_ip_0|pcie_internal_hip|cyclone_iii.cycloneiv_hssi_pcie_hip|coreclkout
+set clkpciecore inst|pcie_subsystem|pcie_ip|pcie_internal_hip|cyclone_iii.cycloneiv_hssi_pcie_hip|coreclkout
 
 derive_pll_clocks -create_base_clocks
 derive_clock_uncertainty
@@ -41,6 +41,11 @@ set_false_path -from [get_registers *]      -to [get_ports oFlash_Clk]
 set_false_path -from [get_registers *]      -to [get_ports oFlash_nCS]
 set_false_path -from [get_registers *]      -to [get_ports oFlash_DI]
 set_false_path -from [get_ports iFlash_DO]  -to [get_registers *]
+
+# ------------------------------------------------------------------------------
+# PCIe
+# -> Cut from/to pcie core clock
+set_clock_groups -asynchronous -group [get_clocks $clkpciecore]
 
 # ------------------------------------------------------------------------------
 # PHY LINK and LEDs

--- a/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/toplevel.vhd
+++ b/hardware/boards/br-antaresif/mn-single-pcie-drv/quartus/toplevel.vhd
@@ -9,6 +9,7 @@
 -------------------------------------------------------------------------------
 --
 --    (c) B&R, 2014
+--    (c) Kalycito Infotech Private Limited, 2015
 --
 --    Redistribution and use in source and binary forms, with or without
 --    modification, are permitted provided that the following conditions
@@ -147,38 +148,35 @@ architecture rtl of toplevel is
             epcs_flash_sce                              : out   std_logic;
             epcs_flash_sdo                              : out   std_logic;
             epcs_flash_data0                            : in    std_logic;
-            pcie_cal_blk_clk_clk                        : in    std_logic;
-            pcie_rx_in_rx_datain_0                      : in    std_logic;
-            pcie_tx_out_tx_dataout_0                    : out   std_logic;
-            pcie_reconfig_togxb_data                    : in    std_logic_vector(3 downto 0);
-            pcie_reconfig_gxbclk_clk                    : in    std_logic;
-            pcie_reconfig_fromgxb_0_data                : out   std_logic_vector(4 downto 0);
-            pcie_refclk_export                          : in    std_logic;
-            pcie_test_in_test_in                        : in    std_logic_vector(39 downto 0);
-            pcie_rstn_export                            : in    std_logic;
-            pcie_clocks_sim_clk250_export               : out   std_logic;
-            pcie_clocks_sim_clk500_export               : out   std_logic;
-            pcie_clocks_sim_clk125_export               : out   std_logic;
-            pcie_reconfig_busy_busy_altgxb_reconfig     : in    std_logic;
-            pcie_pipe_ext_pipe_mode                     : in    std_logic;
-            pcie_pipe_ext_phystatus_ext                 : in    std_logic;
-            pcie_pipe_ext_rate_ext                      : out   std_logic;
-            pcie_pipe_ext_powerdown_ext                 : out   std_logic_vector(1 downto 0);
-            pcie_pipe_ext_txdetectrx_ext                : out   std_logic;
-            pcie_pipe_ext_rxelecidle0_ext               : in    std_logic;
-            pcie_pipe_ext_rxdata0_ext                   : in    std_logic_vector(7 downto 0);
-            pcie_pipe_ext_rxstatus0_ext                 : in    std_logic_vector(2 downto 0);
-            pcie_pipe_ext_rxvalid0_ext                  : in    std_logic;
-            pcie_pipe_ext_rxdatak0_ext                  : in    std_logic;
-            pcie_pipe_ext_txdata0_ext                   : out   std_logic_vector(7 downto 0);
-            pcie_pipe_ext_txdatak0_ext                  : out   std_logic;
-            pcie_pipe_ext_rxpolarity0_ext               : out   std_logic;
-            pcie_pipe_ext_txcompl0_ext                  : out   std_logic;
-            pcie_pipe_ext_txelecidle0_ext               : out   std_logic;
-            pcie_powerdown_pll_powerdown                : in    std_logic;
-            pcie_powerdown_gxb_powerdown                : in    std_logic;
-            pcie_test_out_test_out                      : out   std_logic_vector(8 downto 0);
-            host_benchmark_pio_export                   : out   std_logic_vector(7 downto 0);
+            pcie_ip_rx_in_rx_datain_0                   : in    std_logic                     := 'X';             -- rx_datain_0
+            pcie_ip_tx_out_tx_dataout_0                 : out   std_logic;                                        -- tx_dataout_0
+            pcie_ip_reconfig_togxb_data                 : in    std_logic_vector(3 downto 0)  := (others => 'X'); -- data
+            pcie_ip_reconfig_fromgxb_0_data             : out   std_logic_vector(4 downto 0);                     -- data
+            pcie_ip_refclk_export                       : in    std_logic                     := 'X';
+            pcie_ip_test_in_test_in                     : in    std_logic_vector(39 downto 0);
+            pcie_ip_pcie_rstn_export                    : in    std_logic                     := 'X';             -- export
+            pcie_ip_clocks_sim_clk250_export            : out   std_logic;                                        -- clk250_export
+            pcie_ip_clocks_sim_clk500_export            : out   std_logic;                                        -- clk500_export
+            pcie_ip_clocks_sim_clk125_export            : out   std_logic;                                        -- clk125_export
+            pcie_ip_reconfig_busy_busy_altgxb_reconfig  : in    std_logic                     := 'X';             -- busy_altgxb_reconfig
+            pcie_ip_pipe_ext_pipe_mode                  : in    std_logic                     := 'X';             -- pipe_mode
+            pcie_ip_pipe_ext_phystatus_ext              : in    std_logic                     := 'X';             -- phystatus_ext
+            pcie_ip_pipe_ext_rate_ext                   : out   std_logic;                                        -- rate_ext
+            pcie_ip_pipe_ext_powerdown_ext              : out   std_logic_vector(1 downto 0);                     -- powerdown_ext
+            pcie_ip_pipe_ext_txdetectrx_ext             : out   std_logic;                                        -- txdetectrx_ext
+            pcie_ip_pipe_ext_rxelecidle0_ext            : in    std_logic                     := 'X';             -- rxelecidle0_ext
+            pcie_ip_pipe_ext_rxdata0_ext                : in    std_logic_vector(7 downto 0)  := (others => 'X'); -- rxdata0_ext
+            pcie_ip_pipe_ext_rxstatus0_ext              : in    std_logic_vector(2 downto 0)  := (others => 'X'); -- rxstatus0_ext
+            pcie_ip_pipe_ext_rxvalid0_ext               : in    std_logic                     := 'X';             -- rxvalid0_ext
+            pcie_ip_pipe_ext_rxdatak0_ext               : in    std_logic                     := 'X';             -- rxdatak0_ext
+            pcie_ip_pipe_ext_txdata0_ext                : out   std_logic_vector(7 downto 0);                     -- txdata0_ext
+            pcie_ip_pipe_ext_txdatak0_ext               : out   std_logic;                                        -- txdatak0_ext
+            pcie_ip_pipe_ext_rxpolarity0_ext            : out   std_logic;                                        -- rxpolarity0_ext
+            pcie_ip_pipe_ext_txcompl0_ext               : out   std_logic;                                        -- txcompl0_ext
+            pcie_ip_pipe_ext_txelecidle0_ext            : out   std_logic;                                        -- txelecidle0_ext
+            pcie_ip_powerdown_pll_powerdown             : in    std_logic                     := 'X';             -- pll_powerdown
+            pcie_ip_powerdown_gxb_powerdown             : in    std_logic                     := 'X';             -- gxb_powerdown
+            pcie_0_benchmark_pio_export                 : out   std_logic_vector(7 downto 0);
             pcp_0_cpu_resetrequest_resetrequest         : in    std_logic;
             pcp_0_cpu_resetrequest_resettaken           : out   std_logic;
             pcp_0_powerlink_led_export                  : out   std_logic_vector(1 downto 0);
@@ -265,73 +263,70 @@ begin
 
     inst : component mnSinglePcieDrv
         port map (
-            clk25_clk                               => clk25,
-            clk50_clk                               => clk50,
-            clk100_clk                              => clk100,
-            clk125_clk                              => clk125,
-            reset_reset_n                           => pllLocked,
+            clk25_clk                                   => clk25,
+            clk50_clk                                   => clk50,
+            clk100_clk                                  => clk100,
+            clk125_clk                                  => clk125,
+            reset_reset_n                               => pllLocked,
 
-            pcp_0_cpu_resetrequest_resetrequest     => '0',
-            pcp_0_cpu_resetrequest_resettaken       => open,
+            pcp_0_cpu_resetrequest_resetrequest         => '0',
+            pcp_0_cpu_resetrequest_resettaken           => open,
 
-            tri_state_0_tcm_address_out             => oPlkRamAddr,
-            tri_state_0_tcm_read_n_out              => onPlkRamOE,
-            tri_state_0_tcm_byteenable_n_out        => onPlkRamBE,
-            tri_state_0_tcm_write_n_out             => onPlkRamWE,
-            tri_state_0_tcm_data_out                => bPlkRamData,
-            tri_state_0_tcm_chipselect_n_out        => open,
+            tri_state_0_tcm_address_out                 => oPlkRamAddr,
+            tri_state_0_tcm_read_n_out                  => onPlkRamOE,
+            tri_state_0_tcm_byteenable_n_out            => onPlkRamBE,
+            tri_state_0_tcm_write_n_out                 => onPlkRamWE,
+            tri_state_0_tcm_data_out                    => bPlkRamData,
+            tri_state_0_tcm_chipselect_n_out            => open,
 
-            pcp_0_benchmark_pio_export              => open,
+            pcp_0_benchmark_pio_export                  => open,
 
-            openmac_0_smi_nPhyRst                   => onPlkPhyRst,
-            openmac_0_smi_clk                       => oMDCPlkPhy,
-            openmac_0_smi_dio                       => bMDIOPlkPhy,
-            openmac_0_rmii_txEnable                 => oRmiiTxEn,
-            openmac_0_rmii_txData                   => oRmiiTxData,
-            openmac_0_rmii_rxError                  => iRmiiRxErr,
-            openmac_0_rmii_rxCrsDataValid           => iRmiiCrsDv,
-            openmac_0_rmii_rxData                   => iRmiiRxData,
-            openmac_0_pktactivity_export            => macActivity,
+            openmac_0_smi_nPhyRst                       => onPlkPhyRst,
+            openmac_0_smi_clk                           => oMDCPlkPhy,
+            openmac_0_smi_dio                           => bMDIOPlkPhy,
+            openmac_0_rmii_txEnable                     => oRmiiTxEn,
+            openmac_0_rmii_txData                       => oRmiiTxData,
+            openmac_0_rmii_rxError                      => iRmiiRxErr,
+            openmac_0_rmii_rxCrsDataValid               => iRmiiCrsDv,
+            openmac_0_rmii_rxData                       => iRmiiRxData,
+            openmac_0_pktactivity_export                => macActivity,
 
-            epcs_flash_dclk                         => oFlash_Clk,
-            epcs_flash_sce                          => oFlash_nCS,
-            epcs_flash_sdo                          => oFlash_DI,
-            epcs_flash_data0                        => iFlash_DO,
+            epcs_flash_dclk                             => oFlash_Clk,
+            epcs_flash_sce                              => oFlash_nCS,
+            epcs_flash_sdo                              => oFlash_DI,
+            epcs_flash_data0                            => iFlash_DO,
 
-            pcie_cal_blk_clk_clk                    => clk50,
-            pcie_rx_in_rx_datain_0                  => iPCIe_Rx1p,
-            pcie_tx_out_tx_dataout_0                => oPCIe_Tx1p,
-            pcie_reconfig_togxb_data                => reconfigToGxb,
-            pcie_reconfig_gxbclk_clk                => clk50,
-            pcie_reconfig_fromgxb_0_data            => reconfigFromGxb,
-            pcie_reconfig_busy_busy_altgxb_reconfig => reconfigBusy,
-            pcie_refclk_export                      => iPCIe_RefClk_p,
-            pcie_test_in_test_in                    => (others => cInactivated),
-            pcie_rstn_export                        => pllLocked,
-            pcie_clocks_sim_clk250_export           => open,
-            pcie_clocks_sim_clk500_export           => open,
-            pcie_clocks_sim_clk125_export           => open,
-            pcie_pipe_ext_pipe_mode                 => cInactivated,
-            pcie_pipe_ext_phystatus_ext             => cInactivated,
-            pcie_pipe_ext_rate_ext                  => open,
-            pcie_pipe_ext_powerdown_ext             => open,
-            pcie_pipe_ext_txdetectrx_ext            => open,
-            pcie_pipe_ext_rxelecidle0_ext           => cInactivated,
-            pcie_pipe_ext_rxdata0_ext               => (others => cInactivated),
-            pcie_pipe_ext_rxstatus0_ext             => (others => cInactivated),
-            pcie_pipe_ext_rxvalid0_ext              => cInactivated,
-            pcie_pipe_ext_rxdatak0_ext              => cInactivated,
-            pcie_pipe_ext_txdata0_ext               => open,
-            pcie_pipe_ext_txdatak0_ext              => open,
-            pcie_pipe_ext_rxpolarity0_ext           => open,
-            pcie_pipe_ext_txcompl0_ext              => open,
-            pcie_pipe_ext_txelecidle0_ext           => open,
-            pcie_powerdown_pll_powerdown            => cInactivated,
-            pcie_powerdown_gxb_powerdown            => cInactivated,
-            pcie_test_out_test_out                  => open,
-            host_benchmark_pio_export               => open,
-            pcp_0_powerlink_led_export              => plkSeLed,
-            testport_pio_export                     => testport
+            pcie_ip_rx_in_rx_datain_0                   => iPCIe_Rx1p,
+            pcie_ip_tx_out_tx_dataout_0                 => oPCIe_Tx1p,
+            pcie_ip_reconfig_togxb_data                 => reconfigToGxb,
+            pcie_ip_reconfig_fromgxb_0_data             => reconfigFromGxb,
+            pcie_ip_reconfig_busy_busy_altgxb_reconfig  => reconfigBusy,
+            pcie_ip_refclk_export                       => iPCIe_RefClk_p,
+            pcie_ip_test_in_test_in                     => (others => cInactivated),
+            pcie_ip_pcie_rstn_export                    => pllLocked,
+            pcie_ip_clocks_sim_clk250_export            => open,
+            pcie_ip_clocks_sim_clk500_export            => open,
+            pcie_ip_clocks_sim_clk125_export            => open,
+            pcie_ip_pipe_ext_pipe_mode                  => cInactivated,
+            pcie_ip_pipe_ext_phystatus_ext              => cInactivated,
+            pcie_ip_pipe_ext_rate_ext                   => open,
+            pcie_ip_pipe_ext_powerdown_ext              => open,
+            pcie_ip_pipe_ext_txdetectrx_ext             => open,
+            pcie_ip_pipe_ext_rxelecidle0_ext            => cInactivated,
+            pcie_ip_pipe_ext_rxdata0_ext                => (others => cInactivated),
+            pcie_ip_pipe_ext_rxstatus0_ext              => (others => cInactivated),
+            pcie_ip_pipe_ext_rxvalid0_ext               => cInactivated,
+            pcie_ip_pipe_ext_rxdatak0_ext               => cInactivated,
+            pcie_ip_pipe_ext_txdata0_ext                => open,
+            pcie_ip_pipe_ext_txdatak0_ext               => open,
+            pcie_ip_pipe_ext_rxpolarity0_ext            => open,
+            pcie_ip_pipe_ext_txcompl0_ext               => open,
+            pcie_ip_pipe_ext_txelecidle0_ext            => open,
+            pcie_ip_powerdown_pll_powerdown             => cInactivated,
+            pcie_ip_powerdown_gxb_powerdown             => cInactivated,
+            pcie_0_benchmark_pio_export                 => open,
+            pcp_0_powerlink_led_export                  => plkSeLed,
+            testport_pio_export                         => testport
         );
 
     -- Pll Instance


### PR DESCRIPTION
- Remove PCIe hard Ip from toplevel system.
- Add PCIe subsystem in toplevel system.
- Add PCIe configuration parameters from toplevel.
- Update dualprocshm-mem header with PCIe subsystem memory address.
- Add path to PCIe subsystem in components.ipx.
- Change the frequency of clock signal "clk125" to 125 MHz from
  100 MHz.